### PR TITLE
Naming of CKAN resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@
 
 |Parameter                        |Description                             |
 |---------------------------------|----------------------------------------|
+|**CKAN resource name** |Resource name to create in CKAN  |
+|**Use file name as CKAN resource name** |If checked, file name is used as resource name in CKAN. Must be checked if multiple files on input, otherwise DPU fails  |
 |**Overwrite existing resources** |If checked, existing resources are overwritten  |
+
 
 ***
 
@@ -43,6 +46,7 @@
 
 |Version            |Release notes                                   |
 |-------------------|------------------------------------------------|
+|1.1.0              | Added possibility to name CKAN resource when one file on input |
 |1.0.1              | bug fixes and update in build dependencies |
 |1.0.0              | First release                                   |
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<artifactId>uv-l-filesToCkan</artifactId>
 	<name>L-FilesToCkan</name>
 	<description>Loads files as resources to CKAN catalog</description>
-	<version>1.0.1</version>
+	<version>1.1.0</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/src/main/java/eu/unifiedviews/plugins/loader/filestockan/FilesToCkanConfig_V1.java
+++ b/src/main/java/eu/unifiedviews/plugins/loader/filestockan/FilesToCkanConfig_V1.java
@@ -7,6 +7,10 @@ public class FilesToCkanConfig_V1 {
 
     private Boolean replaceExisting = Boolean.TRUE;
 
+    private String resourceName;
+
+    private boolean useFileNameAsResourceName = false;
+
     public FilesToCkanConfig_V1() {
     }
 
@@ -16,6 +20,22 @@ public class FilesToCkanConfig_V1 {
 
     public void setReplaceExisting(Boolean replaceExisting) {
         this.replaceExisting = replaceExisting;
+    }
+
+    public String getResourceName() {
+        return this.resourceName;
+    }
+
+    public void setResourceName(String resourceName) {
+        this.resourceName = resourceName;
+    }
+
+    public boolean isUseFileNameAsResourceName() {
+        return this.useFileNameAsResourceName;
+    }
+
+    public void setUseFileNameAsResourceName(boolean useFileNameAsResourceName) {
+        this.useFileNameAsResourceName = useFileNameAsResourceName;
     }
 
     @Override

--- a/src/main/java/eu/unifiedviews/plugins/loader/filestockan/FilesToCkanVaadinDialog.java
+++ b/src/main/java/eu/unifiedviews/plugins/loader/filestockan/FilesToCkanVaadinDialog.java
@@ -2,7 +2,8 @@ package eu.unifiedviews.plugins.loader.filestockan;
 
 import com.vaadin.data.util.ObjectProperty;
 import com.vaadin.ui.CheckBox;
-import com.vaadin.ui.FormLayout;
+import com.vaadin.ui.TextField;
+import com.vaadin.ui.VerticalLayout;
 
 import eu.unifiedviews.dpu.config.DPUConfigException;
 import eu.unifiedviews.helpers.dpu.vaadin.dialog.AbstractDialog;
@@ -17,33 +18,65 @@ public class FilesToCkanVaadinDialog extends AbstractDialog<FilesToCkanConfig_V1
 
     private ObjectProperty<Boolean> replaceExisting = new ObjectProperty<Boolean>(Boolean.TRUE);
 
+    private ObjectProperty<Boolean> useFileNameAsResourceName = new ObjectProperty<Boolean>(Boolean.FALSE);
+
+    private TextField txtResourceName;
+
+    private VerticalLayout mainLayout;
+
     public FilesToCkanVaadinDialog() {
         super(FilesToCkan.class);
     }
 
     @Override
     protected void buildDialogLayout() {
-        FormLayout mainLayout = new FormLayout();
-
         // top-level component properties
         setWidth("100%");
         setHeight("100%");
 
-        CheckBox box = new CheckBox(this.ctx.tr("FilesToCkanVaadinDialog.replaceExisting"), replaceExisting);
-        mainLayout.addComponent(box);
+        this.mainLayout = new VerticalLayout();
+        this.mainLayout.setWidth("100%");
+        this.mainLayout.setHeight("-1px");
+        this.mainLayout.setSpacing(true);
+        this.mainLayout.setMargin(true);
 
-        setCompositionRoot(mainLayout);
+        this.txtResourceName = new TextField();
+        this.txtResourceName.setNullRepresentation("");
+        this.txtResourceName.setRequired(false);
+        this.txtResourceName.setCaption(this.ctx.tr("FilesToCkanVaadinDialog.ckan.resource.name"));
+        this.txtResourceName.setWidth("100%");
+        this.txtResourceName.setDescription(this.ctx.tr("FilesToCkanVaadinDialog.resource.name.help"));
+        this.mainLayout.addComponent(this.txtResourceName);
+
+        CheckBox useFileNameAsResourceNameCheckBox = new CheckBox(this.ctx.tr("FilesToCkanVaadinDialog.useFileName"), this.useFileNameAsResourceName);
+        useFileNameAsResourceNameCheckBox.setDescription(this.ctx.tr("FilesToCkanVaadinDialog.useFileName.help"));
+        this.mainLayout.addComponent(useFileNameAsResourceNameCheckBox);
+
+        CheckBox replaceCheckBox = new CheckBox(this.ctx.tr("FilesToCkanVaadinDialog.replaceExisting"), this.replaceExisting);
+        this.mainLayout.addComponent(replaceCheckBox);
+
+        setCompositionRoot(this.mainLayout);
     }
 
     @Override
     public void setConfiguration(FilesToCkanConfig_V1 conf) throws DPUConfigException {
-        replaceExisting.setValue(conf.getReplaceExisting());
+        this.replaceExisting.setValue(conf.getReplaceExisting());
+        this.txtResourceName.setValue(conf.getResourceName());
+        this.useFileNameAsResourceName.setValue(conf.isUseFileNameAsResourceName());
     }
 
     @Override
     public FilesToCkanConfig_V1 getConfiguration() throws DPUConfigException {
+        boolean isValid = (this.txtResourceName.getValue() != null && !this.txtResourceName.getValue().equals(""))
+                || this.useFileNameAsResourceName.getValue();
+        if (!isValid) {
+            throw new DPUConfigException(this.ctx.tr("FilesToCkanVaadinDialog.errors.configuration"));
+        }
+
         FilesToCkanConfig_V1 conf = new FilesToCkanConfig_V1();
-        conf.setReplaceExisting(replaceExisting.getValue());
+        conf.setReplaceExisting(this.replaceExisting.getValue());
+        conf.setResourceName(this.txtResourceName.getValue());
+        conf.setUseFileNameAsResourceName(this.useFileNameAsResourceName.getValue());
         return conf;
     }
 

--- a/src/main/resources/about.html
+++ b/src/main/resources/about.html
@@ -12,6 +12,10 @@ Also, prior to running this DPU, an association between pipeline and CKAN datase
 <p/>
 List of options:
 <ul>
+	<li><b>CKAN resource name</b> - Name of resource to be created in CKAN. It should not change between pipeline runs as this name
+	is used as key to CKAN.</li>
+	<li><b>Use file name as CKAN resource name</b> - (default false) If selected, file name is used as CKAN resource name. When multiple input files,
+	this option must be selected. Otherwise DPU fails  
     <li><b>Overwrite existing resources</b> - (default false) if true and resource with the same name already exists in associated 
     dataset, it is overwritten.</li>
 </ul>

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -7,3 +7,11 @@ FilesToCkan.execute.exception.fail = Failed to update CKAN resource
 FilesToCkan.execute.exception.replaceExisting = Resource {0} already exists at destination
 FilesToCkanVaadinDialog.replaceExisting = Overwrite existing resources
 FilesToCkan.execute.exception.missingSecretToken = No configuration value for secret token
+FilesToCkan.execute.exception.filesCount.short = Wrong count if input files
+FilesToCkan.execute.exception.filesCount.long = DPU can process only one input file when option "Use file name as CKAN resouce name" is not selected
+
+FilesToCkanVaadinDialog.useFileName = Use file name as CKAN resource name
+FilesToCkanVaadinDialog.useFileName.help = When multiple input files and this checkbox is checked, file names are used as resource names; When multiple input files and this option is not checked, DPU fails 
+FilesToCkanVaadinDialog.ckan.resource.name = CKAN resource name 
+FilesToCkanVaadinDialog.resource.name.help = This name should not change between pipeline runs as it is used as key to CKAN. If name changes, existing resource in CKAN will not be updated and new resource will be created
+FilesToCkanVaadinDialog.errors.configuration = Wrong configuration. Resource name must be filled if use file name as resource name option is not selected

--- a/src/main/resources/resources_sk.properties
+++ b/src/main/resources/resources_sk.properties
@@ -7,3 +7,11 @@ FilesToCkan.execute.exception.fail = Chyba pri nahrávaní na CKAN
 FilesToCkan.execute.exception.replaceExisting = Záznam {0} u\u017E existuje
 FilesToCkanVaadinDialog.replaceExisting =  Prepísa\u0165 existujúce zdroje
 FilesToCkan.execute.exception.missingSecretToken = Chýba konfigura\u010Dná hodnota pre autentifika\u010Dný znak
+FilesToCkan.execute.exception.filesCount.short = Nesprávny po\u010Det vstupných súborov
+FilesToCkan.execute.exception.filesCount.long = Krok mô\u017Ee spracova\u0165 len jeden vstupný súbor ak nie je zvolená mo\u017Enos\u0165 "Pou\u017Ei\u0165 meno súboru ako názov zdroja"
+
+FilesToCkanVaadinDialog.useFileName = Pou\u017Ei\u0165 meno súboru ako názov zdroja
+FilesToCkanVaadinDialog.useFileName.help = Ak je na vstupe kroku viacero súborov a je zvolená táto mo\u017Enos\u0165, názvy súborov sú pou\u017Eité ako názvy zdrojov v CKANe. Ak je na vstupe viacero súborov a táto mo\u017Enos\u0165 nie je zvolená, krok zlyhá 
+FilesToCkanVaadinDialog.ckan.resource.name = Názov CKAN zdroja 
+FilesToCkanVaadinDialog.resource.name.help = Tento názov by sa nemal meni\u0165 medzi jednotlivými behmi procesu. Názov zdroja je pou\u017Eitý ako k\u013Eú\u010D do CKANu. Ak sa názov zmení, zdroj v CKANe nebude aktualizovaný a bude vytvorený v\u017Edy nový
+FilesToCkanVaadinDialog.errors.configuration = Nesprávna konfigurácia. Meno zdroja musí by\u0165 vyplnené ak nie je zvolená mo\u017Enos\u0165 pou\u017Eitia názvov súborov


### PR DESCRIPTION
New configuration parameter for naming CKAN resource added. Resource can be named if only one input file. When multiple files on input, the old approach can be used - file names are used as resource names but only if explicitly enabled by configuration, otherwise DPU fails
