### PR TITLE
Change of log level.

### DIFF
--- a/src/main/java/org/opendatanode/plugins/loader/filestockan/FilesToCkan.java
+++ b/src/main/java/org/opendatanode/plugins/loader/filestockan/FilesToCkan.java
@@ -311,7 +311,7 @@ public class FilesToCkan extends AbstractDpu<FilesToCkanConfig_V1> {
                             throw ContextUtils.dpuException(this.ctx, "FilesToCkan.execute.exception.fail");
                         }
                     } else {
-                        LOG.warn("Response:" + EntityUtils.toString(responseUpdate.getEntity()));
+                        LOG.error("Response:" + EntityUtils.toString(responseUpdate.getEntity()));
                         throw ContextUtils.dpuException(this.ctx, "FilesToCkan.execute.exception.fail");
                     }
                 } catch (DPUException ex) {


### PR DESCRIPTION
- when error like "File upload too large" appears this will be logged as Error instead of Warning.
- resloves #16
